### PR TITLE
Update visual.c

### DIFF
--- a/trek/visual.c
+++ b/trek/visual.c
@@ -72,7 +72,7 @@ void
 visual(z)
 	int z __attribute__((__unused__));
 {
-	int		ix, iy;
+	char		ix, iy;
 	int		co;
 	struct xy	*v;
 


### PR DESCRIPTION
adding -1 to the sector coordinates doesn't work with struct xy having unsigned char members and is adding 255 instead. so visual scanning toward lower sector numbers results in scanning sectors like 257,260 that don't exist. setting ix,iy to char is enough for the 0..9 range and is working with negative offsets, too (because of overflow)
